### PR TITLE
Chat history, favorites, and welcome screen for Hit Flow Coach

### DIFF
--- a/netlify/functions/agent-chat.ts
+++ b/netlify/functions/agent-chat.ts
@@ -220,7 +220,7 @@ async function runTool(
       const days = clampDays(input.days, 14, 365);
       const since = isoDaysAgo(days);
       const { data, error } = await supabase
-        .from('supplement_usage')
+        .from('supplement_usages')
         .select('timestamp, dosage_mg, user_supplements:user_supplement_id(supplements:supplement_id(name, brand))')
         .eq('user_id', userId)
         .gte('timestamp', since)

--- a/src/components/AgentChat.tsx
+++ b/src/components/AgentChat.tsx
@@ -1,12 +1,43 @@
-import { useEffect, useRef, useState } from 'react';
-import { MessageCircle, Send, X, Loader2, Wrench, PanelLeft, PanelRight, Move } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  MessageCircle,
+  Send,
+  X,
+  Loader2,
+  Wrench,
+  PanelLeft,
+  PanelRight,
+  Move,
+  Plus,
+  History,
+  Star,
+  StarOff,
+  Trash2,
+  Activity,
+  Dumbbell,
+  TrendingUp,
+  BarChart3,
+  Pill,
+  ListChecks,
+} from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { sendAgentChat, AgentMessage } from '../lib/agentClient';
+import {
+  addFavorite,
+  createThread,
+  deleteThread,
+  listFavorites,
+  listRecentThreads,
+  loadThread,
+  removeFavorite,
+  saveMessage,
+} from '../lib/chatHistory';
+import type { ChatFavorite, ChatThreadMeta, StoredToolCall } from '../types/Chat';
 
 type ChatTurn =
   | { role: 'user'; text: string }
-  | { role: 'assistant'; text: string; toolCalls: string[]; pending: boolean };
+  | { role: 'assistant'; text: string; toolCalls: StoredToolCall[]; pending: boolean };
 
 type ChatMode = 'floating' | 'left' | 'right';
 
@@ -14,6 +45,24 @@ const MIN_WIDTH = 320;
 const MAX_WIDTH = 720;
 const DEFAULT_WIDTH = 420;
 const MOBILE_BREAKPOINT = 768;
+
+const CAPABILITIES: { tool: string; label: string; description: string; icon: React.ReactNode }[] = [
+  { tool: 'list_exercises', label: 'All exercises', description: 'Lists every exercise you log with session counts.', icon: <ListChecks size={12} /> },
+  { tool: 'get_recent_workouts', label: 'Recent workouts', description: 'Pulls workouts across all lifts for a date range.', icon: <Activity size={12} /> },
+  { tool: 'get_exercise_history', label: 'Lift progress', description: 'Weight + TUL trend for a single exercise.', icon: <TrendingUp size={12} /> },
+  { tool: 'compute_workout_stats', label: 'Workout stats', description: 'PRs, session counts, and aggregates over a window.', icon: <BarChart3 size={12} /> },
+  { tool: 'list_user_supplements', label: 'My supplements', description: 'Your personal supplement list and dosages.', icon: <Pill size={12} /> },
+  { tool: 'get_supplement_log', label: 'Supplement log', description: 'Recent supplement intake records.', icon: <Dumbbell size={12} /> },
+];
+
+const EXAMPLE_PROMPTS = [
+  "How's my chest press progressing over the last month?",
+  'What was my heaviest squat this quarter?',
+  'Did I miss any supplements this week?',
+  'How many workouts did I do in the last 30 days?',
+  'Compare my bench and incline press progression.',
+  'Which lift has improved the most recently?',
+];
 
 function loadPref<T>(key: string, fallback: T, parse: (raw: string) => T): T {
   if (typeof window === 'undefined') return fallback;
@@ -25,11 +74,26 @@ function loadPref<T>(key: string, fallback: T, parse: (raw: string) => T): T {
   }
 }
 
+function relativeTime(iso: string): string {
+  const d = new Date(iso).getTime();
+  const diff = Date.now() - d;
+  if (diff < 60_000) return 'just now';
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  if (diff < 604_800_000) return `${Math.floor(diff / 86_400_000)}d ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
 export function AgentChat() {
   const [open, setOpen] = useState(false);
+  const [threadId, setThreadId] = useState<string | null>(null);
   const [turns, setTurns] = useState<ChatTurn[]>([]);
   const [input, setInput] = useState('');
   const [busy, setBusy] = useState(false);
+  const [favorites, setFavorites] = useState<ChatFavorite[]>([]);
+  const [recentThreads, setRecentThreads] = useState<ChatThreadMeta[]>([]);
+  const [showHistory, setShowHistory] = useState(false);
+
   const [mode, setMode] = useState<ChatMode>(() =>
     loadPref<ChatMode>('agentChat.mode', 'floating', (raw) =>
       raw === 'left' || raw === 'right' ? raw : 'floating',
@@ -48,6 +112,7 @@ export function AgentChat() {
 
   const abortRef = useRef<AbortController | null>(null);
   const scrollerRef = useRef<HTMLDivElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
   useEffect(() => {
     scrollerRef.current?.scrollTo({ top: scrollerRef.current.scrollHeight });
@@ -77,12 +142,72 @@ export function AgentChat() {
     return () => window.removeEventListener('resize', onResize);
   }, []);
 
+  const refreshSideData = useCallback(async () => {
+    try {
+      const [favs, threads] = await Promise.all([listFavorites(), listRecentThreads()]);
+      setFavorites(favs);
+      setRecentThreads(threads);
+    } catch (err) {
+      console.error('Failed to load chat side data', err);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open) void refreshSideData();
+  }, [open, refreshSideData]);
+
   const effectiveMode: ChatMode = isMobile ? 'floating' : mode;
 
-  const send = async () => {
-    const text = input.trim();
+  const newChat = () => {
+    setThreadId(null);
+    setTurns([]);
+    setShowHistory(false);
+    void refreshSideData();
+  };
+
+  const openThread = async (id: string) => {
+    setShowHistory(false);
+    try {
+      const messages = await loadThread(id);
+      const loadedTurns: ChatTurn[] = messages.map((m) =>
+        m.role === 'user'
+          ? { role: 'user', text: m.content }
+          : { role: 'assistant', text: m.content, toolCalls: m.tool_calls ?? [], pending: false },
+      );
+      setThreadId(id);
+      setTurns(loadedTurns);
+    } catch (err) {
+      console.error('Failed to load thread', err);
+    }
+  };
+
+  const dropThread = async (id: string) => {
+    try {
+      await deleteThread(id);
+      if (threadId === id) newChat();
+      setRecentThreads((prev) => prev.filter((t) => t.id !== id));
+    } catch (err) {
+      console.error('Failed to delete thread', err);
+    }
+  };
+
+  const send = async (override?: string) => {
+    const text = (override ?? input).trim();
     if (!text || busy) return;
     setInput('');
+
+    let activeThreadId = threadId;
+    let creatingThread = false;
+    if (!activeThreadId) {
+      try {
+        const t = await createThread(text);
+        activeThreadId = t.id;
+        creatingThread = true;
+        setThreadId(t.id);
+      } catch (err) {
+        console.error('Failed to create thread', err);
+      }
+    }
 
     const nextTurns: ChatTurn[] = [
       ...turns,
@@ -91,6 +216,12 @@ export function AgentChat() {
     ];
     setTurns(nextTurns);
     setBusy(true);
+
+    if (activeThreadId) {
+      void saveMessage({ threadId: activeThreadId, role: 'user', content: text }).catch((err) =>
+        console.error('Failed to save user message', err),
+      );
+    }
 
     const history: AgentMessage[] = nextTurns
       .filter((t) => !(t.role === 'assistant' && t.pending))
@@ -101,18 +232,22 @@ export function AgentChat() {
 
     try {
       const reply = await sendAgentChat(history, controller.signal);
+      const toolCalls: StoredToolCall[] = reply.toolCalls.map((c) => ({ name: c.name, input: c.input }));
       setTurns((prev) => {
         const copy = [...prev];
         const last = copy[copy.length - 1];
         if (!last || last.role !== 'assistant') return prev;
-        copy[copy.length - 1] = {
-          ...last,
-          text: reply.text,
-          toolCalls: reply.toolCalls.map((c) => c.name),
-          pending: false,
-        };
+        copy[copy.length - 1] = { ...last, text: reply.text, toolCalls, pending: false };
         return copy;
       });
+      if (activeThreadId) {
+        void saveMessage({
+          threadId: activeThreadId,
+          role: 'assistant',
+          content: reply.text,
+          toolCalls,
+        }).catch((err) => console.error('Failed to save assistant message', err));
+      }
     } catch (err) {
       setTurns((prev) => {
         const copy = [...prev];
@@ -129,6 +264,35 @@ export function AgentChat() {
     } finally {
       setBusy(false);
       abortRef.current = null;
+      if (creatingThread) void refreshSideData();
+    }
+  };
+
+  const pickPrompt = (prompt: string, autosend = false) => {
+    if (autosend) {
+      void send(prompt);
+      return;
+    }
+    setInput(prompt);
+    textareaRef.current?.focus();
+  };
+
+  const favoriteSet = new Set(favorites.map((f) => f.prompt));
+
+  const toggleFavorite = async (prompt: string) => {
+    const clean = prompt.trim();
+    if (!clean) return;
+    const existing = favorites.find((f) => f.prompt === clean);
+    try {
+      if (existing) {
+        await removeFavorite(existing.id);
+        setFavorites((prev) => prev.filter((f) => f.id !== existing.id));
+      } else {
+        const created = await addFavorite(clean);
+        setFavorites((prev) => [created, ...prev.filter((f) => f.prompt !== clean)]);
+      }
+    } catch (err) {
+      console.error('Favorite toggle failed', err);
     }
   };
 
@@ -177,12 +341,13 @@ export function AgentChat() {
   const containerStyle =
     effectiveMode === 'floating' ? undefined : { width: `${sidebarWidth}px` };
 
+  const showWelcome = turns.length === 0;
+
   return (
     <div
       className={`${containerClass} flex flex-col bg-white overflow-hidden`}
       style={containerStyle}
     >
-      {/* Resize handle on the inner edge in sidebar mode */}
       {effectiveMode !== 'floating' && (
         <div
           onMouseDown={startResize}
@@ -194,11 +359,27 @@ export function AgentChat() {
       )}
 
       <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100 bg-gradient-to-r from-blue-500 to-purple-500 text-white">
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 min-w-0">
           <MessageCircle size={18} />
-          <span className="font-semibold text-sm">Hit Flow Coach</span>
+          <span className="font-semibold text-sm truncate">Hit Flow Coach</span>
         </div>
         <div className="flex items-center gap-1">
+          <button
+            onClick={newChat}
+            className="p-1 rounded hover:bg-white/20"
+            title="New chat"
+            aria-label="New chat"
+          >
+            <Plus size={16} />
+          </button>
+          <button
+            onClick={() => setShowHistory((s) => !s)}
+            className={`p-1 rounded ${showHistory ? 'bg-white/30' : 'hover:bg-white/20'}`}
+            title="History"
+            aria-label="History"
+          >
+            <History size={16} />
+          </button>
           {!isMobile && (
             <>
               <button
@@ -239,134 +420,46 @@ export function AgentChat() {
         </div>
       </div>
 
-      <div ref={scrollerRef} className="flex-1 overflow-y-auto px-4 py-3 space-y-3">
-        {turns.length === 0 && (
-          <div className="text-sm text-gray-500 mt-4">
-            <p className="mb-2">Ask about your training. For example:</p>
-            <ul className="space-y-1 text-xs">
-              <li>· "How's my chest press progressing over the last month?"</li>
-              <li>· "What was my heaviest squat this quarter?"</li>
-              <li>· "Did I miss any supplements this week?"</li>
-            </ul>
+      <div ref={scrollerRef} className="flex-1 overflow-y-auto">
+        {showHistory ? (
+          <HistoryView
+            threads={recentThreads}
+            currentId={threadId}
+            onOpen={openThread}
+            onDelete={dropThread}
+            onClose={() => setShowHistory(false)}
+          />
+        ) : showWelcome ? (
+          <WelcomeView
+            favorites={favorites}
+            recentThreads={recentThreads}
+            onPick={pickPrompt}
+            onToggleFavorite={toggleFavorite}
+            onOpenThread={openThread}
+          />
+        ) : (
+          <div className="px-4 py-3 space-y-3">
+            {turns.map((t, i) => (
+              <MessageBubble
+                key={i}
+                turn={t}
+                isFavorited={t.role === 'user' && favoriteSet.has(t.text.trim())}
+                onToggleFavorite={() => t.role === 'user' && toggleFavorite(t.text)}
+              />
+            ))}
           </div>
         )}
-        {turns.map((t, i) => (
-          <div
-            key={i}
-            className={`max-w-[85%] rounded-2xl px-3 py-2 text-sm ${
-              t.role === 'user'
-                ? 'ml-auto bg-blue-600 text-white whitespace-pre-wrap'
-                : 'mr-auto bg-gray-100 text-gray-900'
-            }`}
-          >
-            {t.role === 'assistant' && t.toolCalls.length > 0 && (
-              <div className="flex flex-wrap gap-1 mb-1">
-                {t.toolCalls.map((name, j) => (
-                  <span
-                    key={j}
-                    className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wide bg-white text-gray-600 border border-gray-200 rounded-full px-2 py-0.5"
-                  >
-                    <Wrench size={10} />
-                    {name}
-                  </span>
-                ))}
-              </div>
-            )}
-            {t.role === 'assistant' ? (
-              t.text ? (
-                <div className="prose-chat">
-                  <ReactMarkdown
-                    remarkPlugins={[remarkGfm]}
-                    components={{
-                      a: ({ node, ...props }) => (
-                        <a
-                          {...props}
-                          target="_blank"
-                          rel="noreferrer noopener"
-                          className="text-blue-600 underline"
-                        />
-                      ),
-                      table: ({ node, ...props }) => (
-                        <table
-                          {...props}
-                          className="my-2 text-xs border-collapse border border-gray-300"
-                        />
-                      ),
-                      th: ({ node, ...props }) => (
-                        <th
-                          {...props}
-                          className="border border-gray-300 bg-gray-50 px-2 py-1 text-left font-semibold"
-                        />
-                      ),
-                      td: ({ node, ...props }) => (
-                        <td {...props} className="border border-gray-300 px-2 py-1" />
-                      ),
-                      code: ({ node, className, children, ...props }) => {
-                        const inline = !className;
-                        return inline ? (
-                          <code
-                            {...props}
-                            className="bg-gray-200 text-gray-800 px-1 py-0.5 rounded text-[0.85em]"
-                          >
-                            {children}
-                          </code>
-                        ) : (
-                          <code {...props} className={className}>
-                            {children}
-                          </code>
-                        );
-                      },
-                      pre: ({ node, ...props }) => (
-                        <pre
-                          {...props}
-                          className="my-2 bg-gray-900 text-gray-100 p-2 rounded-md text-xs overflow-x-auto"
-                        />
-                      ),
-                      ul: ({ node, ...props }) => (
-                        <ul {...props} className="list-disc pl-5 my-1 space-y-0.5" />
-                      ),
-                      ol: ({ node, ...props }) => (
-                        <ol {...props} className="list-decimal pl-5 my-1 space-y-0.5" />
-                      ),
-                      p: ({ node, ...props }) => <p {...props} className="my-1" />,
-                      h1: ({ node, ...props }) => (
-                        <h1 {...props} className="text-base font-bold mt-2 mb-1" />
-                      ),
-                      h2: ({ node, ...props }) => (
-                        <h2 {...props} className="text-sm font-bold mt-2 mb-1" />
-                      ),
-                      h3: ({ node, ...props }) => (
-                        <h3 {...props} className="text-sm font-semibold mt-1.5 mb-1" />
-                      ),
-                      blockquote: ({ node, ...props }) => (
-                        <blockquote
-                          {...props}
-                          className="border-l-2 border-gray-300 pl-3 my-1 text-gray-700"
-                        />
-                      ),
-                    }}
-                  >
-                    {t.text}
-                  </ReactMarkdown>
-                </div>
-              ) : (
-                t.pending && <Loader2 size={14} className="animate-spin text-gray-400" />
-              )
-            ) : (
-              t.text
-            )}
-          </div>
-        ))}
       </div>
 
       <div className="border-t border-gray-100 p-2 flex items-center gap-2">
         <textarea
+          ref={textareaRef}
           value={input}
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={(e) => {
             if (e.key === 'Enter' && !e.shiftKey) {
               e.preventDefault();
-              send();
+              void send();
             }
           }}
           placeholder="Ask about your workouts or supplements…"
@@ -375,13 +468,327 @@ export function AgentChat() {
           disabled={busy}
         />
         <button
-          onClick={send}
+          onClick={() => void send()}
           disabled={busy || !input.trim()}
           className="p-2 rounded-full bg-blue-600 text-white disabled:bg-gray-300 disabled:cursor-not-allowed hover:bg-blue-700"
           aria-label="Send message"
         >
           {busy ? <Loader2 size={18} className="animate-spin" /> : <Send size={18} />}
         </button>
+      </div>
+    </div>
+  );
+}
+
+function WelcomeView(props: {
+  favorites: ChatFavorite[];
+  recentThreads: ChatThreadMeta[];
+  onPick: (prompt: string) => void;
+  onToggleFavorite: (prompt: string) => void;
+  onOpenThread: (id: string) => void;
+}) {
+  const { favorites, recentThreads, onPick, onToggleFavorite, onOpenThread } = props;
+  const favSet = new Set(favorites.map((f) => f.prompt));
+  return (
+    <div className="px-4 py-4 space-y-5 text-sm">
+      <div>
+        <p className="text-gray-700 mb-2">
+          Hi! I can analyze your training and supplement data. Here's what I can pull:
+        </p>
+        <div className="flex flex-wrap gap-1.5">
+          {CAPABILITIES.map((cap) => (
+            <span
+              key={cap.tool}
+              title={cap.description}
+              className="inline-flex items-center gap-1 text-[11px] bg-blue-50 text-blue-700 border border-blue-100 rounded-full px-2 py-0.5"
+            >
+              {cap.icon}
+              {cap.label}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <section>
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2">
+          Try one
+        </h3>
+        <ul className="space-y-1">
+          {EXAMPLE_PROMPTS.map((p) => (
+            <li key={p}>
+              <PromptRow
+                text={p}
+                favorited={favSet.has(p)}
+                onPick={() => onPick(p)}
+                onToggleFavorite={() => onToggleFavorite(p)}
+              />
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section>
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2">
+          ⭐ Saved
+        </h3>
+        {favorites.length === 0 ? (
+          <p className="text-xs text-gray-400">
+            Star a prompt above or any question you ask to keep it here.
+          </p>
+        ) : (
+          <ul className="space-y-1">
+            {favorites.map((f) => (
+              <li key={f.id}>
+                <PromptRow
+                  text={f.prompt}
+                  favorited
+                  onPick={() => onPick(f.prompt)}
+                  onToggleFavorite={() => onToggleFavorite(f.prompt)}
+                />
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section>
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2">
+          Recent chats
+        </h3>
+        {recentThreads.length === 0 ? (
+          <p className="text-xs text-gray-400">No chats yet — your conversations appear here.</p>
+        ) : (
+          <ul className="space-y-1">
+            {recentThreads.slice(0, 6).map((t) => (
+              <li key={t.id}>
+                <button
+                  onClick={() => onOpenThread(t.id)}
+                  className="w-full text-left flex items-center justify-between gap-2 px-2 py-1.5 rounded-lg hover:bg-gray-50"
+                >
+                  <span className="truncate text-gray-700">{t.title}</span>
+                  <span className="text-[10px] text-gray-400 whitespace-nowrap">
+                    {relativeTime(t.updated_at)}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function PromptRow(props: {
+  text: string;
+  favorited: boolean;
+  onPick: () => void;
+  onToggleFavorite: () => void;
+}) {
+  return (
+    <div className="group flex items-center gap-1 rounded-lg hover:bg-gray-50">
+      <button
+        onClick={props.onPick}
+        className="flex-1 text-left px-2 py-1.5 text-gray-800 text-sm rounded-lg"
+      >
+        {props.text}
+      </button>
+      <button
+        onClick={props.onToggleFavorite}
+        className={`p-1.5 rounded-md ${
+          props.favorited
+            ? 'text-yellow-500'
+            : 'text-gray-300 opacity-0 group-hover:opacity-100 hover:text-gray-500'
+        }`}
+        title={props.favorited ? 'Remove from saved' : 'Save prompt'}
+        aria-label={props.favorited ? 'Remove from saved' : 'Save prompt'}
+      >
+        {props.favorited ? <Star size={14} fill="currentColor" /> : <Star size={14} />}
+      </button>
+    </div>
+  );
+}
+
+function HistoryView(props: {
+  threads: ChatThreadMeta[];
+  currentId: string | null;
+  onOpen: (id: string) => void;
+  onDelete: (id: string) => void;
+  onClose: () => void;
+}) {
+  return (
+    <div className="px-4 py-3 text-sm">
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500">All chats</h3>
+        <button
+          onClick={props.onClose}
+          className="text-xs text-blue-600 hover:underline"
+        >
+          Done
+        </button>
+      </div>
+      {props.threads.length === 0 ? (
+        <p className="text-xs text-gray-400">You don't have any saved chats yet.</p>
+      ) : (
+        <ul className="space-y-1">
+          {props.threads.map((t) => (
+            <li
+              key={t.id}
+              className={`group flex items-center gap-1 rounded-lg ${
+                t.id === props.currentId ? 'bg-blue-50' : 'hover:bg-gray-50'
+              }`}
+            >
+              <button
+                onClick={() => props.onOpen(t.id)}
+                className="flex-1 text-left px-2 py-1.5 min-w-0"
+              >
+                <div className="truncate text-gray-800">{t.title}</div>
+                <div className="text-[10px] text-gray-400">{relativeTime(t.updated_at)}</div>
+              </button>
+              <button
+                onClick={() => props.onDelete(t.id)}
+                className="p-1.5 rounded-md text-gray-300 opacity-0 group-hover:opacity-100 hover:text-red-500"
+                title="Delete chat"
+                aria-label="Delete chat"
+              >
+                <Trash2 size={14} />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function MessageBubble(props: {
+  turn: ChatTurn;
+  isFavorited: boolean;
+  onToggleFavorite: () => void;
+}) {
+  const t = props.turn;
+  return (
+    <div className={`group flex ${t.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+      {t.role === 'user' && (
+        <button
+          onClick={props.onToggleFavorite}
+          className={`self-center mr-1 p-1 rounded-md ${
+            props.isFavorited
+              ? 'text-yellow-500 opacity-100'
+              : 'text-gray-300 opacity-0 group-hover:opacity-100 hover:text-gray-500'
+          }`}
+          title={props.isFavorited ? 'Saved' : 'Save prompt'}
+          aria-label={props.isFavorited ? 'Saved prompt' : 'Save prompt'}
+        >
+          {props.isFavorited ? (
+            <Star size={14} fill="currentColor" />
+          ) : (
+            <StarOff size={14} />
+          )}
+        </button>
+      )}
+      <div
+        className={`max-w-[85%] rounded-2xl px-3 py-2 text-sm ${
+          t.role === 'user'
+            ? 'bg-blue-600 text-white whitespace-pre-wrap'
+            : 'bg-gray-100 text-gray-900'
+        }`}
+      >
+        {t.role === 'assistant' && t.toolCalls.length > 0 && (
+          <div className="flex flex-wrap gap-1 mb-1">
+            {t.toolCalls.map((c, j) => (
+              <span
+                key={j}
+                title={`Called ${c.name}`}
+                className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wide bg-white text-gray-600 border border-gray-200 rounded-full px-2 py-0.5"
+              >
+                <Wrench size={10} />
+                {c.name}
+              </span>
+            ))}
+          </div>
+        )}
+        {t.role === 'assistant' ? (
+          t.text ? (
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              components={{
+                a: ({ node, ...props }) => (
+                  <a
+                    {...props}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    className="text-blue-600 underline"
+                  />
+                ),
+                table: ({ node, ...props }) => (
+                  <table
+                    {...props}
+                    className="my-2 text-xs border-collapse border border-gray-300"
+                  />
+                ),
+                th: ({ node, ...props }) => (
+                  <th
+                    {...props}
+                    className="border border-gray-300 bg-gray-50 px-2 py-1 text-left font-semibold"
+                  />
+                ),
+                td: ({ node, ...props }) => (
+                  <td {...props} className="border border-gray-300 px-2 py-1" />
+                ),
+                code: ({ node, className, children, ...props }) => {
+                  const inline = !className;
+                  return inline ? (
+                    <code
+                      {...props}
+                      className="bg-gray-200 text-gray-800 px-1 py-0.5 rounded text-[0.85em]"
+                    >
+                      {children}
+                    </code>
+                  ) : (
+                    <code {...props} className={className}>
+                      {children}
+                    </code>
+                  );
+                },
+                pre: ({ node, ...props }) => (
+                  <pre
+                    {...props}
+                    className="my-2 bg-gray-900 text-gray-100 p-2 rounded-md text-xs overflow-x-auto"
+                  />
+                ),
+                ul: ({ node, ...props }) => (
+                  <ul {...props} className="list-disc pl-5 my-1 space-y-0.5" />
+                ),
+                ol: ({ node, ...props }) => (
+                  <ol {...props} className="list-decimal pl-5 my-1 space-y-0.5" />
+                ),
+                p: ({ node, ...props }) => <p {...props} className="my-1" />,
+                h1: ({ node, ...props }) => (
+                  <h1 {...props} className="text-base font-bold mt-2 mb-1" />
+                ),
+                h2: ({ node, ...props }) => (
+                  <h2 {...props} className="text-sm font-bold mt-2 mb-1" />
+                ),
+                h3: ({ node, ...props }) => (
+                  <h3 {...props} className="text-sm font-semibold mt-1.5 mb-1" />
+                ),
+                blockquote: ({ node, ...props }) => (
+                  <blockquote
+                    {...props}
+                    className="border-l-2 border-gray-300 pl-3 my-1 text-gray-700"
+                  />
+                ),
+              }}
+            >
+              {t.text}
+            </ReactMarkdown>
+          ) : (
+            t.pending && <Loader2 size={14} className="animate-spin text-gray-400" />
+          )
+        ) : (
+          t.text
+        )}
       </div>
     </div>
   );

--- a/src/lib/chatHistory.ts
+++ b/src/lib/chatHistory.ts
@@ -1,0 +1,106 @@
+import { supabase } from './supabase';
+import type {
+  ChatFavorite,
+  ChatThreadMeta,
+  StoredChatMessage,
+  StoredToolCall,
+} from '../types/Chat';
+
+async function getUserId(): Promise<string> {
+  const { data } = await supabase.auth.getUser();
+  if (!data.user) throw new Error('Not authenticated');
+  return data.user.id;
+}
+
+function titleFromPrompt(prompt: string): string {
+  const clean = prompt.replace(/\s+/g, ' ').trim();
+  return clean.length > 60 ? `${clean.slice(0, 57)}…` : clean || 'New chat';
+}
+
+export async function createThread(firstUserMessage: string): Promise<ChatThreadMeta> {
+  const user_id = await getUserId();
+  const { data, error } = await supabase
+    .from('chat_threads')
+    .insert({ user_id, title: titleFromPrompt(firstUserMessage) })
+    .select('id, title, created_at, updated_at')
+    .single();
+  if (error) throw error;
+  return data as ChatThreadMeta;
+}
+
+export async function saveMessage(args: {
+  threadId: string;
+  role: 'user' | 'assistant';
+  content: string;
+  toolCalls?: StoredToolCall[];
+}): Promise<void> {
+  const user_id = await getUserId();
+  const { error } = await supabase.from('chat_messages').insert({
+    thread_id: args.threadId,
+    user_id,
+    role: args.role,
+    content: args.content,
+    tool_calls: args.toolCalls ?? null,
+  });
+  if (error) throw error;
+  // Bump thread updated_at so it sorts to the top of the list.
+  await supabase
+    .from('chat_threads')
+    .update({ updated_at: new Date().toISOString() })
+    .eq('id', args.threadId);
+}
+
+export async function listRecentThreads(limit = 15): Promise<ChatThreadMeta[]> {
+  const { data, error } = await supabase
+    .from('chat_threads')
+    .select('id, title, created_at, updated_at')
+    .order('updated_at', { ascending: false })
+    .limit(limit);
+  if (error) throw error;
+  return (data as ChatThreadMeta[]) ?? [];
+}
+
+export async function loadThread(threadId: string): Promise<StoredChatMessage[]> {
+  const { data, error } = await supabase
+    .from('chat_messages')
+    .select('id, thread_id, role, content, tool_calls, created_at')
+    .eq('thread_id', threadId)
+    .order('created_at');
+  if (error) throw error;
+  return (data as StoredChatMessage[]) ?? [];
+}
+
+export async function deleteThread(threadId: string): Promise<void> {
+  const { error } = await supabase.from('chat_threads').delete().eq('id', threadId);
+  if (error) throw error;
+}
+
+export async function listFavorites(): Promise<ChatFavorite[]> {
+  const { data, error } = await supabase
+    .from('chat_favorites')
+    .select('id, prompt, created_at')
+    .order('created_at', { ascending: false });
+  if (error) throw error;
+  return (data as ChatFavorite[]) ?? [];
+}
+
+export async function addFavorite(prompt: string): Promise<ChatFavorite> {
+  const user_id = await getUserId();
+  const clean = prompt.trim();
+  if (!clean) throw new Error('Prompt is empty');
+  const { data, error } = await supabase
+    .from('chat_favorites')
+    .upsert(
+      { user_id, prompt: clean },
+      { onConflict: 'user_id,prompt', ignoreDuplicates: false },
+    )
+    .select('id, prompt, created_at')
+    .single();
+  if (error) throw error;
+  return data as ChatFavorite;
+}
+
+export async function removeFavorite(id: string): Promise<void> {
+  const { error } = await supabase.from('chat_favorites').delete().eq('id', id);
+  if (error) throw error;
+}

--- a/src/types/Chat.ts
+++ b/src/types/Chat.ts
@@ -1,0 +1,25 @@
+export type ChatRole = 'user' | 'assistant';
+
+export type StoredToolCall = { name: string; input: unknown };
+
+export type ChatThreadMeta = {
+  id: string;
+  title: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type StoredChatMessage = {
+  id: string;
+  thread_id: string;
+  role: ChatRole;
+  content: string;
+  tool_calls: StoredToolCall[] | null;
+  created_at: string;
+};
+
+export type ChatFavorite = {
+  id: string;
+  prompt: string;
+  created_at: string;
+};

--- a/supabase-chat-schema.sql
+++ b/supabase-chat-schema.sql
@@ -1,0 +1,59 @@
+-- Chat history + favorites for Hit Flow Coach.
+-- Run this in the Supabase SQL editor.
+
+create table if not exists public.chat_threads (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  title text not null default 'New chat',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists chat_threads_user_updated_idx
+  on public.chat_threads (user_id, updated_at desc);
+
+create table if not exists public.chat_messages (
+  id uuid primary key default gen_random_uuid(),
+  thread_id uuid not null references public.chat_threads(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  role text not null check (role in ('user', 'assistant')),
+  content text not null,
+  tool_calls jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists chat_messages_thread_created_idx
+  on public.chat_messages (thread_id, created_at);
+
+create table if not exists public.chat_favorites (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  prompt text not null,
+  created_at timestamptz not null default now(),
+  unique (user_id, prompt)
+);
+
+create index if not exists chat_favorites_user_created_idx
+  on public.chat_favorites (user_id, created_at desc);
+
+alter table public.chat_threads enable row level security;
+alter table public.chat_messages enable row level security;
+alter table public.chat_favorites enable row level security;
+
+create policy "Users manage own chat threads"
+  on public.chat_threads
+  for all
+  using (user_id = auth.uid())
+  with check (user_id = auth.uid());
+
+create policy "Users manage own chat messages"
+  on public.chat_messages
+  for all
+  using (user_id = auth.uid())
+  with check (user_id = auth.uid());
+
+create policy "Users manage own chat favorites"
+  on public.chat_favorites
+  for all
+  using (user_id = auth.uid())
+  with check (user_id = auth.uid());


### PR DESCRIPTION
## Summary

Builds on the merged #20 (Coach chat MVP). Three additions plus a small pre-existing bug fix:

1. **Persisted chat history** in Supabase (per-user, RLS-scoped). Conversations survive across browsers and devices.
2. **Favorites** — save useful prompts and re-run them with a click.
3. **Welcome screen** that surfaces what Coach can do (capability chips per tool), offers clickable starter prompts, and lists recent chats + saved prompts.

## What changed

**Database** — new schema in [`supabase-chat-schema.sql`](supabase-chat-schema.sql):
- `chat_threads(id, user_id, title, created_at, updated_at)` — one row per conversation, auto-titled from the first user message
- `chat_messages(id, thread_id, user_id, role, content, tool_calls jsonb, created_at)` — messages with tool calls preserved as JSONB so chips re-render on reload
- `chat_favorites(id, user_id, prompt)` — unique on `(user_id, prompt)`
- RLS policies scope every row to `auth.uid()`. No service-role key needed.

**Frontend**:
- New [`src/lib/chatHistory.ts`](src/lib/chatHistory.ts) — create/save/load/delete thread + message + favorite helpers
- New [`src/types/Chat.ts`](src/types/Chat.ts) — shared types
- [`src/components/AgentChat.tsx`](src/components/AgentChat.tsx) extended with:
  - **Welcome view** (shown until you start chatting): capability chips for all 6 tools with hover descriptions, 6 clickable starter prompts, a ⭐ Saved list, and Recent chats (last 6)
  - **History view** (header button): full list of past threads with delete buttons
  - **New chat** button (`+` in header) — clears panel for a fresh thread
  - **Star icons** — hover over a starter prompt or any of your own user messages to save/unsave
- Threads are created lazily on the first send (avoids empty threads)
- Reopening a thread restores its tool-call chips from stored JSONB

**Bug fix**: function was querying `supplement_usage` (singular) but the table is `supplement_usages` (plural) per [supabase-rls-policies.sql](supabase-rls-policies.sql). Would have silently returned 0 supplement rows. Now corrected.

## One step before deploy

Run [`supabase-chat-schema.sql`](supabase-chat-schema.sql) once in the Supabase SQL editor. The frontend will throw on first message send if the tables don't exist. One-time only; RLS policies are included.

## Test plan

- [ ] Run the SQL migration in Supabase; confirm three tables appear with RLS enabled
- [ ] Open chat — welcome screen shows 6 capability chips, 6 starter prompts, empty Saved/Recent sections
- [ ] Click a starter prompt → it populates the input (not auto-sent)
- [ ] Send a message → reply renders, conversation persists; close + reopen the panel → "Recent chats" shows it
- [ ] Click the star next to a user message → it appears in Saved
- [ ] Click `+` New chat → welcome screen returns
- [ ] Click History icon → all threads listed with timestamps; delete one
- [ ] Reopen an old thread → tool-call chips render correctly
- [ ] Verify cross-account isolation: log in as a second user, confirm no leakage of threads/favorites (RLS sanity)
- [ ] Ask a supplement question (e.g. "Did I miss any supplements this week?") — confirm it now returns data (was broken by the `supplement_usage` typo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)